### PR TITLE
Use SHA-256 by default instead of SHA-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Usage
     -r NUMBER  LUKS slot number for temporary reset passphrase
                Default: 2
     -L STRING  List of PCR banks used to seal LUKS key
-               Default: sha1:0,2,4,7
+               Default: sha256:0,2,4,7
     -l STRING  List of PCR banks used to unseal LUKS key
                Default: <value of -L>
     -T STRING  TCTI module used to communicate with the TPM
@@ -130,7 +130,7 @@ on the TPM. In this example, we create a primary RSA key in the owner hierarchy
 and make it persistent at handle `0x81000001`:
 
     $ sudo -E tpm2_listpersistent
-    $ sudo -E tpm2_createprimary -H o -g sha1 -G rsa -C primary.ctx
+    $ sudo -E tpm2_createprimary -H o -g sha256 -G rsa -C primary.ctx
     $ sudo -E tpm2_evictcontrol -A o -S 0x81000001 -c primary.ctx
 
 Next, call `luks-tpm2` with appropriate options:
@@ -147,7 +147,7 @@ password will need to be supplied during operations that require the parent key.
 The `-K` option will cause `luks-tpm2` to display an interactive password
 prompt. `-k PATH` will instead attempt to read the password from a file at PATH.
 
-    $ sudo -E tpm2_createprimary -H o -g sha1 -G rsa -C primary.ctx -K MyPassword
+    $ sudo -E tpm2_createprimary -H o -g sha256 -G rsa -C primary.ctx -K MyPassword
     $ sudo -E tpm2_evictcontrol -A o -S 0x81000001 -c primary.ctx
     $ sudo -E luks-tpm2 -p /boot/keyfile -H 0x81000001 -K /dev/sdaX init
 

--- a/default
+++ b/default
@@ -30,6 +30,6 @@
 #KEY_SIZE=32
 #TPM_KEY_SLOT=1
 #RESET_KEY_SLOT=2
-#PCRS="sha1:0,2,4,7"
-#UNSEAL_PCRS="sha1:0,2,4,7"
+#PCRS="sha256:0,2,4,7"
+#UNSEAL_PCRS="sha256:0,2,4,7"
 #TPM2TOOLS_TCTI="device:/dev/tpmrm0"

--- a/luks-tpm2
+++ b/luks-tpm2
@@ -51,7 +51,7 @@ Options:
   -r NUMBER  LUKS slot number for temporary reset passphrase
              Default: 2
   -L STRING  List of PCR banks used to seal LUKS key
-             Default: sha1:0,2,4,7
+             Default: sha256:0,2,4,7
   -l STRING  List of PCR banks used to unseal LUKS key
              Default: <value of -L>
   -T STRING  TCTI module used to communicate with the TPM
@@ -230,7 +230,7 @@ set_parent_key() {
 
   if [ -n "$PARENT_KEY_PROMPT" ]; then
     read -s -p "Enter parent key password: " parent_key
-    echo 
+    echo
   elif [ -f "$PARENT_KEY_PATH" ]; then
     parent_key=$(cat "$PARENT_KEY_PATH")
   fi
@@ -260,7 +260,7 @@ load_defaults() {
   KEY_SIZE=32
   TPM_KEY_SLOT=1
   RESET_KEY_SLOT=2
-  PCRS="sha1:0,2,4,7"
+  PCRS="sha256:0,2,4,7"
   UNSEAL_PCRS=""
   TPM2TOOLS_TCTI="${TPM2TOOLS_TCTI:-device:/dev/tpmrm0}"
 


### PR DESCRIPTION
TPM-2 allows using SHA-256 so change defaults to take advantage of the stronger digest function.