### PR TITLE
Update to tpm2-tools 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Requirements
 This script requires:
 
   * [bash](https://www.gnu.org/software/bash/)
-  * [tpm2-tools](https://github.com/tpm2-software/tpm2-tools) v3.1
+  * [tpm2-tools](https://github.com/tpm2-software/tpm2-tools) v4
   * [cryptsetup](https://gitlab.com/cryptsetup/cryptsetup)
   * A TPM 2.0 or TPM 2.0 simulator
 
@@ -118,24 +118,30 @@ altered since the data was sealed.
 
 Note that all TPM objects will be created in the owner hierarchy.
 
-Before working with the TPM, condiser setting the `TPM2TOOLS_TCTI` environment
+Before working with the TPM, consider setting the `TPM2TOOLS_TCTI` environment
 variable for your TPM resource manager. For example, to use the in-kernel RM:
 
     $ export TPM2TOOLS_TCTI=device:/dev/tpmrm0
+
+If you want to be able to access the TPM as a normal user, add yourself to the
+`tss` group, otherwise you will have to run all the following `tpm2_` commands
+as root.
 
 ## On-disk
 
 Before storing sealed key files on disk, you must create a parent encryption key
 on the TPM. In this example, we create a primary RSA key in the owner hierarchy
-and make it persistent at handle `0x81000001`:
+and make it persistent:
 
-    $ sudo -E tpm2_listpersistent
-    $ sudo -E tpm2_createprimary -H o -g sha1 -G rsa -C primary.ctx
-    $ sudo -E tpm2_evictcontrol -A o -S 0x81000001 -c primary.ctx
+    $ tpm2_createprimary -c primary.ctx
+    $ tpm2_evictcontrol -c primary.ctx
+
+Look at the output for `persistent-handle` of the last command, e.g.
+`0x81000000`, and use it in the following commands.
 
 Next, call `luks-tpm2` with appropriate options:
 
-    $ sudo -E luks-tpm2 -p /boot/keyfile -H 0x81000001 /dev/sdaX init
+    $ sudo -E luks-tpm2 -p /boot/keyfile -H 0x81000000 /dev/sdaX init
 
 Two sealed files will be generated (in `/boot` for this example):
 `/boot/keyfile.priv` and `/boot/keyfile.pub`.
@@ -147,9 +153,9 @@ password will need to be supplied during operations that require the parent key.
 The `-K` option will cause `luks-tpm2` to display an interactive password
 prompt. `-k PATH` will instead attempt to read the password from a file at PATH.
 
-    $ sudo -E tpm2_createprimary -H o -g sha1 -G rsa -C primary.ctx -K MyPassword
-    $ sudo -E tpm2_evictcontrol -A o -S 0x81000001 -c primary.ctx
-    $ sudo -E luks-tpm2 -p /boot/keyfile -H 0x81000001 -K /dev/sdaX init
+    $ tpm2_createprimary -c primary.ctx -p MyPassword
+    $ tpm2_evictcontrol -c primary.ctx
+    $ sudo -E luks-tpm2 -p /boot/keyfile -H 0x81000000 -K /dev/sdaX init
 
 ## NVRAM
 
@@ -160,7 +166,7 @@ required.
 
 Before initializing NVRAM storage, locate a free index:
 
-    $ sudo -E tpm2_nvlist
+    $ tpm2_getcap handles-nv-index
 
 And then call `luks-tpm2` with appropriate options:
 

--- a/luks-tpm2
+++ b/luks-tpm2
@@ -178,12 +178,12 @@ destroy_ramfs() {
 unseal_key() {
   if use_nvram; then
     echo "Reading key from TPM NVRAM..."
-    tpm2_nvread -x $NVRAM_INDEX -a $NVRAM_INDEX -L "$UNSEAL_PCRS" -f "$KEYFILE" >/dev/null
+    tpm2_nvread $NVRAM_INDEX -P "pcr:$UNSEAL_PCRS" -o "$KEYFILE" >/dev/null
   else
     echo "Unsealing keyfile..."
     set_parent_key
-    tpm2_load -H $PARENT_HANDLE "${parent_key[@]}" -r "$SEALED_KEY_PRIVATE" -u "$SEALED_KEY_PUBLIC" -C "$OBJECT_CONTEXT" >/dev/null
-    tpm2_unseal -c "$OBJECT_CONTEXT" -o "$KEYFILE" -L "$UNSEAL_PCRS" >/dev/null
+    tpm2_load -C $PARENT_HANDLE "${parent_key[@]}" -r "$SEALED_KEY_PRIVATE" -u "$SEALED_KEY_PUBLIC" -c "$OBJECT_CONTEXT" >/dev/null
+    tpm2_unseal -c "$OBJECT_CONTEXT" -o "$KEYFILE" -p "pcr:$UNSEAL_PCRS" >/dev/null
     retval=$?
     rm -f "$OBJECT_CONTEXT"
     return $retval
@@ -192,27 +192,27 @@ unseal_key() {
 
 # Seal a key to the TPM
 seal_key() {
-  if ! tpm2_createpolicy -P -L "$PCRS" -f "$POLICY_DIGEST" >/dev/null; then
+  if ! tpm2_createpolicy --policy-pcr -l "$PCRS" -L "$POLICY_DIGEST" >/dev/null; then
     return 1
   fi
 
   if use_nvram; then
     echo "Storing key in TPM NVRAM..."
-    if ! tpm2_getcap -c properties-variable 2>&1 | grep ownerAuthSet | grep -sq clear; then
+    if ! tpm2_getcap properties-variable 2>&1 | grep ownerAuthSet | grep -sq 0; then
       read -s -p "Enter TPM owner password: " tpm_auth_pass
       echo
       [ -n "$tpm_auth_pass" ] && tpm_auth_pass="-P $tpm_auth_pass"
     fi
 
-    tpm2_nvrelease -x "$NVRAM_INDEX" -a 0x40000001 $tpm_auth_pass >/dev/null 2>&1
-    tpm2_nvdefine -x "$NVRAM_INDEX" -a 0x40000001 $tpm_auth_pass -L "$POLICY_DIGEST" -s $KEY_SIZE -t "policyread|policywrite" >/dev/null
-    tpm2_nvwrite -x "$NVRAM_INDEX" -a "$NVRAM_INDEX" -L "$PCRS" "$KEYFILE" >/dev/null
+    tpm2_nvundefine "$NVRAM_INDEX" $tpm_auth_pass >/dev/null 2>&1
+    tpm2_nvdefine "$NVRAM_INDEX" $tpm_auth_pass -L "$POLICY_DIGEST" -s $KEY_SIZE -a "policyread|policywrite" >/dev/null
+    tpm2_nvwrite "$NVRAM_INDEX" -P "pcr:$PCRS" -i "$KEYFILE" >/dev/null
   else
     echo "Sealing keyfile with the TPM..."
     rm -f "$SEALED_KEY_PRIVATE" "$SEALED_KEY_PUBLIC"
 
     set_parent_key
-    tpm2_create -H "$PARENT_HANDLE" -g sha256 -G keyedhash -A 0x492 "${parent_key[@]}" -I "$KEYFILE" -L "$POLICY_DIGEST" -r "$SEALED_KEY_PRIVATE" -u "$SEALED_KEY_PUBLIC" >/dev/null
+    tpm2_create -C "$PARENT_HANDLE" -a 'fixedtpm|fixedparent|adminwithpolicy|noda' "${parent_key[@]}" -i "$KEYFILE" -L "$POLICY_DIGEST" -r "$SEALED_KEY_PRIVATE" -u "$SEALED_KEY_PUBLIC" >/dev/null
   fi
   retval=$?
 


### PR DESCRIPTION
tpm2-tools 4.0 has been [released](https://github.com/tpm2-software/tpm2-tools/releases/tag/4.0) and is already in the repositories of [Arch Linux](https://www.archlinux.org/packages/community/x86_64/tpm2-tools/) and [Fedora](https://apps.fedoraproject.org/packages/tpm2-tools), hence this project should be update to use the latest release. Many option names have changed, and tpm2-tools 4 has better defaults handling, making some options unnecessary altogether.