### PR TITLE
Wrong variable set for TPM key size

### DIFF
--- a/luks-tpm2
+++ b/luks-tpm2
@@ -332,7 +332,7 @@ parse_args() {
           echo "Invalid key size: $OPTARG" >&2
           exit 1
         fi
-        TPM_KEY_SLOT=$OPTARG
+        KEY_SIZE=$OPTARG
         ;;
       t)
         if [[ ! $OPTARG =~ ^-?[0-9]+$ ]] || [ $OPTARG -lt 0 ] || [ $OPTARG -gt 7 ]; then


### PR DESCRIPTION
If option s was passed with TPM key size the TPM_KEY_SLOT variable was being set instead of KEY_SIZE.