### PR TITLE
Add option to supply existing keyfile instead of being asked for a passphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Usage
     -x HEX     Index of the TPM NVRAM area holding the key
     -s NUMBER  Key size in byes
                Default: 32
+    -f PATH    LUKS keyfile used instead of prompting for LUKS passphraes
     -t NUMBER  LUKS slot number for the TPM key
                Default: 1
     -r NUMBER  LUKS slot number for temporary reset passphrase

--- a/luks-tpm2
+++ b/luks-tpm2
@@ -343,7 +343,7 @@ parse_args() {
         TPM_KEY_SLOT=$OPTARG
         ;;
       f)
-        if [ ! -f "$OPTARG" ];
+        if [ ! -f "$OPTARG" ]; then
           echo "Keyfile does not exist: $OPTARG" >&2
           exit 1
         fi

--- a/luks-tpm2
+++ b/luks-tpm2
@@ -47,6 +47,7 @@ Options:
   -x HEX      Index of the TPM NVRAM area holding the key
   -s NUMBER   Key size in bytes
               Default: 32
+  -f PATH     LUKS keyfile used instead of prompting for LUKS passphraes
   -t NUMBER   LUKS slot number for the TPM key
               Default: 1
   -r NUMBER   LUKS slot number for temporary reset passphrase
@@ -73,17 +74,23 @@ init_tpm_key() {
     return
   fi
 
-  read -r -s -p "Enter any existing LUKS passphrase: " PASSPHRASE
-  echo
+  ARGS=""
+  if [ -n "$LUKS_KEYFILE_PATH" ]; then
+    ARGS="--key-file -"
+    PASSPHRASE=$(cat "$LUKS_KEYFILE_PATH")
+  else
+    read -r -s -p "Enter any existing LUKS passphrase: " PASSPHRASE
+    echo
+  fi
 
   echo "Generating new LUKS key..."
   generate_keyfile
 
   echo "Removing existing key from slot $TPM_KEY_SLOT..."
-  echo $PASSPHRASE | cryptsetup luksKillSlot $ROOT_DEVICE $TPM_KEY_SLOT
+  echo $PASSPHRASE | cryptsetup luksKillSlot $ARGS $ROOT_DEVICE $TPM_KEY_SLOT
 
   echo "Adding new key to slot $TPM_KEY_SLOT..."
-  echo $PASSPHRASE | cryptsetup luksAddKey $ROOT_DEVICE "$KEYFILE" --new-key-slot $TPM_KEY_SLOT
+  echo $PASSPHRASE | cryptsetup luksAddKey $ARGS $ROOT_DEVICE "$KEYFILE" --new-key-slot $TPM_KEY_SLOT
   addkey=$?
 
   seal_key
@@ -276,6 +283,7 @@ load_defaults() {
   PARENT_HANDLE="0x81000001"
   PARENT_KEY_PROMPT=""
   PARENT_KEY_PATH=""
+  LUKS_KEYFILE_PATH=""
   NVRAM_INDEX=""
   KEY_SIZE=32
   TPM_KEY_SLOT=1
@@ -333,6 +341,13 @@ parse_args() {
           exit 1
         fi
         TPM_KEY_SLOT=$OPTARG
+        ;;
+      f)
+        if [ ! -f "$OPTARG" ];
+          echo "Keyfile does not exist: $OPTARG" >&2
+          exit 1
+        fi
+        LUKS_KEYFILE_PATH="$OPTARG"
         ;;
       t)
         if [[ ! $OPTARG =~ ^-?[0-9]+$ ]] || [ $OPTARG -lt 0 ] || [ $OPTARG -gt 7 ]; then

--- a/luks-tpm2
+++ b/luks-tpm2
@@ -303,7 +303,7 @@ load_defaults() {
 parse_args() {
   ORIGINAL_ARGS="$@"
 
-  while getopts ":hvm:p:H:Kk:x:s:t:r:L:l:T:c:" opt; do
+  while getopts ":hvm:p:H:Kk:x:s:f:t:r:L:l:T:c:" opt; do
     case $opt in
       h)
         version

--- a/luks-tpm2
+++ b/luks-tpm2
@@ -76,8 +76,7 @@ init_tpm_key() {
 
   ARGS=""
   if [ -n "$LUKS_KEYFILE_PATH" ]; then
-    ARGS="--key-file -"
-    PASSPHRASE=$(cat "$LUKS_KEYFILE_PATH")
+    ARGS="--key-file $LUKS_KEYFILE_PATH"
   else
     read -r -s -p "Enter any existing LUKS passphrase: " PASSPHRASE
     echo


### PR DESCRIPTION
This PR implements an option `-f` which can be used to supply a keyfile instead of being asked for passphrase. 
For automated setups (I'm using ansible) this is very useful.