### PR TITLE
Add -o option to write the generated tpm-sealed keyfile to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Usage
     -s NUMBER  Key size in byes
                Default: 32
     -f PATH    LUKS keyfile used instead of prompting for LUKS passphraes
+    -o PATH    Optionally write the new LUKS keyfile sealed in the tpm to this path
     -t NUMBER  LUKS slot number for the TPM key
                Default: 1
     -r NUMBER  LUKS slot number for temporary reset passphrase

--- a/luks-tpm2
+++ b/luks-tpm2
@@ -272,7 +272,8 @@ set_parent_key() {
 generate_keyfile() {
   dd bs=$KEY_SIZE count=1 if=/dev/urandom of="$KEYFILE" >/dev/null 2>&1
   if [ -n "$NEW_KEYFILE_OUTPUT_PATH" ]; then
-    umask 777
+    touch "$NEW_KEYFILE_OUTPUT_PATH"
+    chmod 400 "$NEW_KEYFILE_OUTPUT_PATH"
     cp "$KEYFILE" "$NEW_KEYFILE_OUTPUT_PATH"
   fi
 }

--- a/luks-tpm2
+++ b/luks-tpm2
@@ -268,8 +268,10 @@ set_parent_key() {
 # Generate a random key of KEY_SIZE bytes
 generate_keyfile() {
   dd bs=$KEY_SIZE count=1 if=/dev/urandom of="$KEYFILE" >/dev/null 2>&1
-  umask 777
-  cp "$KEYFILE" "$NEW_KEYFILE_OUTPUT_PATH"
+  if [ -n "$NEW_KEYFILE_OUTPUT_PATH" ]; then
+    umask 777
+    cp "$KEYFILE" "$NEW_KEYFILE_OUTPUT_PATH"
+  fi
 }
 
 # Find first LUKS boock device

--- a/luks-tpm2
+++ b/luks-tpm2
@@ -48,6 +48,7 @@ Options:
   -s NUMBER   Key size in bytes
               Default: 32
   -f PATH     LUKS keyfile used instead of prompting for LUKS passphraes
+  -o PATH     Optionally write the new LUKS keyfile sealed in the tpm to this path
   -t NUMBER   LUKS slot number for the TPM key
               Default: 1
   -r NUMBER   LUKS slot number for temporary reset passphrase
@@ -267,6 +268,8 @@ set_parent_key() {
 # Generate a random key of KEY_SIZE bytes
 generate_keyfile() {
   dd bs=$KEY_SIZE count=1 if=/dev/urandom of="$KEYFILE" >/dev/null 2>&1
+  umask 777
+  cp "$KEYFILE" "$NEW_KEYFILE_OUTPUT_PATH"
 }
 
 # Find first LUKS boock device
@@ -283,6 +286,7 @@ load_defaults() {
   PARENT_KEY_PROMPT=""
   PARENT_KEY_PATH=""
   LUKS_KEYFILE_PATH=""
+  NEW_KEYFILE_OUTPUT_PATH=""
   NVRAM_INDEX=""
   KEY_SIZE=32
   TPM_KEY_SLOT=1
@@ -302,7 +306,7 @@ load_defaults() {
 parse_args() {
   ORIGINAL_ARGS="$@"
 
-  while getopts ":hvm:p:H:Kk:x:s:f:t:r:L:l:T:c:" opt; do
+  while getopts ":hvm:p:H:Kk:x:s:f:o:t:r:L:l:T:c:" opt; do
     case $opt in
       h)
         version
@@ -347,6 +351,9 @@ parse_args() {
           exit 1
         fi
         LUKS_KEYFILE_PATH="$OPTARG"
+        ;;
+      o)
+        NEW_KEYFILE_OUTPUT_PATH="$OPTARG"
         ;;
       t)
         if [[ ! $OPTARG =~ ^-?[0-9]+$ ]] || [ $OPTARG -lt 0 ] || [ $OPTARG -gt 7 ]; then


### PR DESCRIPTION
This is as far as I can see the last PR of my little patch series :-)

As I am using this on a bunch of systems that get updated automatically, I have created a initramfs update hook which automatically creates a new key and seals it to the new PCR with `tpm_futurepcr` (using `luks-tpm2 compute`).

Unfortunately, under some circumstances, there are multiple changes to the initramfs before a reboot is done. This can happen for example when both the kernel and the `initramfs-tools` package are updated at once. In this situation, the second change fails, because the keyfile is sealed to the new PCR and we cannot unseal it, as the system still has the old PCR (since no reboot has happened yet).

My solution for this is to write out the new keyfile to a tmpfs (which is automatically gone after a reboot), and use that keyfile (with the new keyfile input option from my earlier PR) if another change to the initramfs happens before the reboot actually happens.

This PR implements an option `-o` with which a path to write the keyfile to can be specified.